### PR TITLE
Mark Image as Obsolete in Track DTO

### DIFF
--- a/src/Schema/Tracks/Track.cs
+++ b/src/Schema/Tracks/Track.cs
@@ -53,6 +53,7 @@ namespace SevenDigital.Api.Schema.Tracks
 		[XmlElement("url")]
 		public string Url { get; set; }
 
+		[Obsolete("This is not on the track response")]
 		[XmlElement("image")]
 		public string Image { get; set; }
 


### PR DESCRIPTION
The Image property in the Track DTO is seemingly never populated.  We have gone through the endpoints in the Schema that use `Track` and none have anything other than `null` for the Image property.  Therefore, we have marked Image as obsolete.