### PR TITLE
Add Status field to a playlist

### DIFF
--- a/src/Schema/Playlists/PlaylistStatusType.cs
+++ b/src/Schema/Playlists/PlaylistStatusType.cs
@@ -1,0 +1,9 @@
+﻿namespace SevenDigital.Api.Schema.Playlists
+{
+	public enum PlaylistStatusType
+	{
+		NotSpecified,
+		Draft,
+		Published
+	}
+}

--- a/src/Schema/Playlists/Requests/PlaylistDetailsRequest.cs
+++ b/src/Schema/Playlists/Requests/PlaylistDetailsRequest.cs
@@ -12,5 +12,8 @@ namespace SevenDigital.Api.Schema.Playlists.Requests
 
 		[XmlElement("visibility")]
 		public PlaylistVisibilityType Visibility { get; set; }
+
+		[XmlElement("status")]
+		public PlaylistStatusType Status { get; set; }
 	}
 }

--- a/src/Schema/Playlists/Response/Endpoints/PlaylistDetails.cs
+++ b/src/Schema/Playlists/Response/Endpoints/PlaylistDetails.cs
@@ -20,6 +20,9 @@ namespace SevenDigital.Api.Schema.Playlists.Response.Endpoints
 		[XmlElement("visibility")]
 		public PlaylistVisibilityType Visibility { get; set; }
 
+		[XmlElement("status")]
+		public PlaylistStatusType Status { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1}", Id, Name);

--- a/src/Schema/Playlists/Response/PlaylistLocation.cs
+++ b/src/Schema/Playlists/Response/PlaylistLocation.cs
@@ -23,6 +23,9 @@ namespace SevenDigital.Api.Schema.Playlists.Response
 		[XmlElement("visibility")]
 		public PlaylistVisibilityType Visibility { get; set; }
 
+		[XmlElement("status")]
+		public PlaylistStatusType Status { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1}", Id, Name);

--- a/src/Schema/Schema.csproj
+++ b/src/Schema/Schema.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Payments\PaymentCardTypes.cs" />
     <Compile Include="Playlists\HasPlaylistIdParameter.cs" />
     <Compile Include="Playlists\HasPlaylistTrackIdParameter.cs" />
+    <Compile Include="Playlists\PlaylistStatusType.cs" />
     <Compile Include="Playlists\PlaylistVisibilityType.cs" />
     <Compile Include="Playlists\Product.cs" />
     <Compile Include="Playlists\Requests\PlaylistDetailsRequest.cs" />


### PR DESCRIPTION
 - Status is shown when you list playlists and when you get back
   playlist details
 - Status is in the playlist request when creating and updating
   playlists
 - Status defaults to not specified if no status is provided