### PR TITLE
New fields when usageTypes is specified

### DIFF
--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
@@ -95,6 +95,19 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			Assert.That(package.Price.RecommendedRetailPrice, Is.GreaterThan(0));
 		}
 
+		[Test]
+		public async Task Release_has_subscription_streaming_when_requested()
+		{
+			var request = _api.Create<Release>()
+				.ForReleaseId(1685647)
+				.WithParameter("country", "GB")
+				.WithParameter("usageTypes", "subscriptionStreaming");
+
+			var release = await request.Please();
+
+			Assert.That(release.SubscriptionStreaming, Is.Not.Null);
+		}
+
 		private async Task<Release> GetTestRelease()
 		{
 			var request = _api.Create<Release>()

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
@@ -125,6 +125,19 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			Assert.That(release.Download.Packages, Is.Not.Empty);
 		}
 
+		[Test]
+		public async Task Release_has_slug_when_usage_types_are_requested()
+		{
+			var request = _api.Create<Release>()
+			.ForReleaseId(12345)
+			.WithParameter("country", "GB")
+			.WithParameter("usageTypes", "download,subscriptionStreaming");
+
+			var release = await request.Please();
+			Assert.That(release.Slug, Is.Not.Null);
+			Assert.That(release.Artist.Slug, Is.Not.Null);
+		}
+
 		private async Task<Release> GetTestRelease()
 		{
 			var request = _api.Create<Release>()

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseDetailsTests.cs
@@ -106,6 +106,23 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			var release = await request.Please();
 
 			Assert.That(release.SubscriptionStreaming, Is.Not.Null);
+			Assert.That(release.SubscriptionStreaming.ReleaseDate, Is.Not.EqualTo(default(DateTime)));
+		}
+
+		[Test]
+		public async Task Release_has_download_when_requested()
+		{
+			var request = _api.Create<Release>()
+				.ForReleaseId(12345)
+				.WithParameter("country", "GB")
+				.WithParameter("usageTypes", "download");
+
+			var release = await request.Please();
+
+			Assert.That(release.Download, Is.Not.Null);
+			Assert.That(release.Download.ReleaseDate, Is.Not.EqualTo(default(DateTime)));
+			Assert.That(release.Download.PreviewDate, Is.Not.EqualTo(default(DateTime)));
+			Assert.That(release.Download.Packages, Is.Not.Empty);
 		}
 
 		private async Task<Release> GetTestRelease()

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
@@ -116,5 +116,18 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			Assert.That(price, Is.Not.Null);
 			Assert.That(price.SevendigitalPrice.HasValue, Is.False);
 		}
+
+		[Test]
+		public async Task Track_has_subscription_streaming_when_requested()
+		{
+			var request = _api.Create<ReleaseTracks>()
+				.ForReleaseId(394123)
+				.WithParameter("usageTypes", "subscriptionStreaming");
+			var releaseTracks = await request.Please();
+
+			Assert.That(releaseTracks.Tracks.Count, Is.GreaterThanOrEqualTo(1));
+			var subscriptionStreaming = releaseTracks.Tracks.Select(t => t.SubscriptionStreaming);
+			Assert.That(subscriptionStreaming, Is.All.Not.Null);
+		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
@@ -118,7 +118,7 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 		}
 
 		[Test]
-		public async Task Track_has_subscription_streaming_when_requested()
+		public async Task Tracks_have_subscription_streaming_when_requested()
 		{
 			var request = _api.Create<ReleaseTracks>()
 				.ForReleaseId(394123)
@@ -131,7 +131,7 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 		}
 
 		[Test]
-		public async Task Track_has_download_when_requested()
+		public async Task Tracks_have_download_when_requested()
 		{
 			var request = _api.Create<ReleaseTracks>()
 				.ForReleaseId(1996067)
@@ -141,6 +141,23 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			Assert.That(releaseTracks.Tracks.Count, Is.GreaterThanOrEqualTo(1));
 			var download = releaseTracks.Tracks.Select(t => t.Download);
 			Assert.That(download, Is.All.Not.Null);
+		}
+
+		[Test]
+		public async Task Tracks_have_slug_when_usage_types_is_requested()
+		{
+			var request = _api.Create<ReleaseTracks>()
+				.ForReleaseId(1996067)
+				.WithParameter("usageTypes", "download,subscriptionStreaming");
+			var releaseTracks = await request.Please();
+
+			Assert.That(releaseTracks.Tracks.Count, Is.GreaterThanOrEqualTo(1));
+			var trackArtistSlugs = releaseTracks.Tracks.Select(t => t.Artist.Slug);
+			var trackReleaseSlugs = releaseTracks.Tracks.Select(t => t.Release.Slug);
+			var trackReleaseArtistSlugs = releaseTracks.Tracks.Select(t => t.Release.Artist.Slug);
+			Assert.That(trackArtistSlugs, Is.All.Not.Null);
+			Assert.That(trackReleaseSlugs, Is.All.Not.Null);
+			Assert.That(trackReleaseArtistSlugs, Is.All.Not.Null);
 		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleaseTracksTests.cs
@@ -129,5 +129,18 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			var subscriptionStreaming = releaseTracks.Tracks.Select(t => t.SubscriptionStreaming);
 			Assert.That(subscriptionStreaming, Is.All.Not.Null);
 		}
+
+		[Test]
+		public async Task Track_has_download_when_requested()
+		{
+			var request = _api.Create<ReleaseTracks>()
+				.ForReleaseId(1996067)
+				.WithParameter("usageTypes", "download");
+			var releaseTracks = await request.Please();
+
+			Assert.That(releaseTracks.Tracks.Count, Is.GreaterThanOrEqualTo(1));
+			var download = releaseTracks.Tracks.Select(t => t.Download);
+			Assert.That(download, Is.All.Not.Null);
+		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SevenDigital.Api.Schema.Integration.Tests.Infrastructure;
+using SevenDigital.Api.Schema.Packages;
 using SevenDigital.Api.Schema.Releases;
 using SevenDigital.Api.Wrapper;
 
@@ -107,6 +109,28 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 
 			Assert.That(response.Errors, Is.Not.Null);
 			Assert.That(response.Errors.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public async Task Should_return_subscription_streaming_when_requested()
+		{
+			var ids = new List<int> { FirstId };
+			var request = _api.Create<ReleasesBatch>()
+				.WithParameter("releaseids", ids)
+				.WithParameter("usageTypes", "subscriptionStreaming")
+				.ForShop(34);
+
+
+			var response = await request.Please();
+
+			Assert.That(response, Is.Not.Null);
+
+			Assert.That(response.Releases, Is.Not.Null);
+			Assert.That(response.Releases.Count, Is.EqualTo(1));
+
+			var subscriptionStreaming = response.Releases.Select(r => r.SubscriptionStreaming).ToList();
+			Assert.That(subscriptionStreaming.Count, Is.EqualTo(1));
+			Assert.That(subscriptionStreaming[0], Is.Not.Null);
 		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -131,6 +132,32 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			var subscriptionStreaming = response.Releases.Select(r => r.SubscriptionStreaming).ToList();
 			Assert.That(subscriptionStreaming.Count, Is.EqualTo(1));
 			Assert.That(subscriptionStreaming[0], Is.Not.Null);
+			Assert.That(subscriptionStreaming[0].ReleaseDate, Is.Not.EqualTo(default(DateTime)));
+		}
+
+		[Test]
+		public async Task Should_return_download_when_requested()
+		{
+			var ids = new List<int> { FirstId, SecondId };
+			var request = _api.Create<ReleasesBatch>()
+				.WithParameter("releaseids", ids)
+				.WithParameter("usageTypes", "download")
+				.ForShop(34);
+
+
+			var response = await request.Please();
+
+			Assert.That(response, Is.Not.Null);
+
+			Assert.That(response.Releases, Is.Not.Null);
+			Assert.That(response.Releases.Count, Is.EqualTo(2));
+
+			var download = response.Releases.Select(r => r.Download).ToList();
+			Assert.That(download.Count, Is.EqualTo(2));
+			Assert.That(download, Is.All.Not.Null);
+			Assert.That(download.Select(d => d.ReleaseDate), Is.All.Not.EqualTo(default(DateTime)));
+			Assert.That(download.Select(d => d.PreviewDate), Is.All.Not.EqualTo(default(DateTime)));
+			Assert.That(download.Select(d => d.Packages), Is.All.Not.Empty);
 		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Releases/ReleasesBatchTests.cs
@@ -159,5 +159,23 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Releases
 			Assert.That(download.Select(d => d.PreviewDate), Is.All.Not.EqualTo(default(DateTime)));
 			Assert.That(download.Select(d => d.Packages), Is.All.Not.Empty);
 		}
+
+		[Test]
+		public async Task Release_has_slug_when_usage_types_are_requested()
+		{
+			var ids = new List<int> { FirstId, SecondId };
+			var request = _api.Create<ReleasesBatch>()
+				.WithParameter("releaseids", ids)
+				.WithParameter("usageTypes", "download,subscriptionStreaming")
+				.ForShop(34);
+
+			var response = await request.Please();
+
+			var releaseSlugs = response.Releases.Select(r => r.Slug);
+			var artistSlugs = response.Releases.Select(r => r.Artist.Slug);
+			Assert.That(releaseSlugs, Is.All.Not.Null);
+			Assert.That(artistSlugs, Is.All.Not.Null);
+		}
+
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
@@ -125,6 +125,20 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 				.WithParameter("usageTypes", "subscriptionStreaming");
 			var track = await request.Please();
 			Assert.That(track.SubscriptionStreaming, Is.Not.Null);
+			Assert.That(track.SubscriptionStreaming.ReleaseDate, Is.Not.EqualTo(default(DateTime)));
+		}
+
+		[Test]
+		public async Task Track_has_download_when_requested()
+		{
+			var request = _api.Create<Track>()
+				.ForTrackId(12345)
+				.WithParameter("usageTypes", "download");
+			var track = await request.Please();
+			Assert.That(track.Download, Is.Not.Null);
+			Assert.That(track.Download.ReleaseDate, Is.Not.EqualTo(default(DateTime)));
+			Assert.That(track.Download.PreviewDate, Is.Not.EqualTo(default(DateTime)));
+			Assert.That(track.Download.Packages, Is.Not.Empty);
 		}
 
 		private async Task<Track> GetTestTrack()

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
@@ -141,6 +141,18 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 			Assert.That(track.Download.Packages, Is.Not.Empty);
 		}
 
+		[Test]
+		public async Task Track_has_slug_when_usage_types_are_requested()
+		{
+			var request = _api.Create<Track>()
+				.ForTrackId(12345)
+				.WithParameter("usageTypes", "download,subscriptionStreaming");
+			var track = await request.Please();
+			Assert.That(track.Artist.Slug, Is.Not.Null);
+			Assert.That(track.Release.Slug, Is.Not.Null);
+			Assert.That(track.Release.Artist.Slug, Is.Not.Null);
+		}
+
 		private async Task<Track> GetTestTrack()
 		{
 			var request = _api.Create<Track>()

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TrackDetailsTests.cs
@@ -117,6 +117,16 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 			Assert.That(primaryPackage.Formats[0].Description, Is.EqualTo("MP3 320"));
 		}
 
+		[Test]
+		public async Task Track_has_subscription_streaming_when_requested()
+		{
+			var request = _api.Create<Track>()
+				.ForTrackId(12345)
+				.WithParameter("usageTypes", "subscriptionStreaming");
+			var track = await request.Please();
+			Assert.That(track.SubscriptionStreaming, Is.Not.Null);
+		}
+
 		private async Task<Track> GetTestTrack()
 		{
 			var request = _api.Create<Track>()

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
@@ -127,5 +127,22 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 			Assert.That(subscriptionStreaming.Count, Is.EqualTo(2));
 			Assert.That(subscriptionStreaming, Is.All.Not.Null);
 		}
+
+		[Test]
+		public async Task Track_has_download_streaming_when_requested()
+		{
+			var ids = new List<int> { FirstId, SecondId };
+			var request = _api.Create<TracksBatch>()
+				.WithParameter("trackids", ids)
+				.WithParameter("usageTypes", "download")
+				.ForShop(34);
+
+			var response = await request.Please();
+
+			Assert.That(response.Tracks.Count, Is.EqualTo(2));
+			var download = response.Tracks.Select(t => t.Download).ToList();
+			Assert.That(download.Count, Is.EqualTo(2));
+			Assert.That(download, Is.All.Not.Null);
+		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SevenDigital.Api.Schema.Integration.Tests.Infrastructure;
@@ -108,6 +109,23 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 
 			Assert.That(response.Errors, Is.Not.Null);
 			Assert.That(response.Errors.Count, Is.EqualTo(0));
+		}
+
+		[Test]
+		public async Task Track_has_subscription_streaming_when_requested()
+		{
+			var ids = new List<int> { FirstId, SecondId };
+			var request = _api.Create<TracksBatch>()
+				.WithParameter("trackids", ids)
+				.WithParameter("usageTypes", "subscriptionStreaming")
+				.ForShop(34);
+
+			var response = await request.Please();
+
+			Assert.That(response.Tracks.Count, Is.EqualTo(2));
+			var subscriptionStreaming = response.Tracks.Select(t => t.SubscriptionStreaming).ToList();
+			Assert.That(subscriptionStreaming.Count, Is.EqualTo(2));
+			Assert.That(subscriptionStreaming, Is.All.Not.Null);
 		}
 	}
 }

--- a/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
+++ b/src/Schema.Integration.Tests/EndpointTests/Tracks/TracksBatchTests.cs
@@ -112,7 +112,7 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 		}
 
 		[Test]
-		public async Task Track_has_subscription_streaming_when_requested()
+		public async Task Tracks_have_subscription_streaming_when_requested()
 		{
 			var ids = new List<int> { FirstId, SecondId };
 			var request = _api.Create<TracksBatch>()
@@ -129,7 +129,7 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 		}
 
 		[Test]
-		public async Task Track_has_download_streaming_when_requested()
+		public async Task Tracks_have_download_streaming_when_requested()
 		{
 			var ids = new List<int> { FirstId, SecondId };
 			var request = _api.Create<TracksBatch>()
@@ -143,6 +143,24 @@ namespace SevenDigital.Api.Schema.Integration.Tests.EndpointTests.Tracks
 			var download = response.Tracks.Select(t => t.Download).ToList();
 			Assert.That(download.Count, Is.EqualTo(2));
 			Assert.That(download, Is.All.Not.Null);
+		}
+
+		[Test]
+		public async Task Tracks_have_slugs_when_usage_types_is_requested()
+		{
+			var ids = new List<int> { FirstId, SecondId };
+			var request = _api.Create<TracksBatch>()
+				.WithParameter("trackids", ids)
+				.WithParameter("usageTypes", "download,subscriptionStreaming")
+				.ForShop(34);
+
+			var response = await request.Please();
+			var releaseSlugs = response.Tracks.Select(t => t.Release.Slug);
+			var releaseArtistSlugs = response.Tracks.Select(t => t.Release.Artist.Slug);
+			var artistSlugs = response.Tracks.Select(t => t.Artist.Slug);
+			Assert.That(releaseSlugs, Is.All.Not.Null);
+			Assert.That(releaseArtistSlugs, Is.All.Not.Null);
+			Assert.That(artistSlugs, Is.All.Not.Null);
 		}
 	}
 }

--- a/src/Schema/Artists/Artist.cs
+++ b/src/Schema/Artists/Artist.cs
@@ -28,6 +28,9 @@ namespace SevenDigital.Api.Schema.Artists
 		[XmlElement("url")]
 		public string Url { get; set; }
 
+		[XmlElement("slug")]
+		public string Slug { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1}", Id, Name);

--- a/src/Schema/Packages/Download.cs
+++ b/src/Schema/Packages/Download.cs
@@ -11,6 +11,9 @@ namespace SevenDigital.Api.Schema.Packages
 		[XmlElement("releaseDate")]
 		public DateTime ReleaseDate { get; set; }
 
+		[XmlElement("previewDate")]
+		public DateTime? PreviewDate { get; set; }
+
 		[XmlArray("packages")]
 		[XmlArrayItem("package")]
 		public List<Package> Packages { get; set; }

--- a/src/Schema/Packages/Streaming.cs
+++ b/src/Schema/Packages/Streaming.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Xml.Serialization;
+
+namespace SevenDigital.Api.Schema.Packages
+{
+	public class Streaming
+	{
+		[XmlElement("releaseDate")]
+		public DateTime ReleaseDate { get; set; }
+	}
+}

--- a/src/Schema/Releases/Release.cs
+++ b/src/Schema/Releases/Release.cs
@@ -89,6 +89,9 @@ namespace SevenDigital.Api.Schema.Releases
 		[XmlElement("download")]
 		public Download Download { get; set; }
 
+		[XmlElement("subscriptionStreaming")]
+		public Streaming SubscriptionStreaming { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1} {2} {3}, Barcode {4}", Id, Title, Version, Type, Barcode);

--- a/src/Schema/Releases/Release.cs
+++ b/src/Schema/Releases/Release.cs
@@ -92,6 +92,9 @@ namespace SevenDigital.Api.Schema.Releases
 		[XmlElement("subscriptionStreaming")]
 		public Streaming SubscriptionStreaming { get; set; }
 
+		[XmlElement("slug")]
+		public string Slug { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1} {2} {3}, Barcode {4}", Id, Title, Version, Type, Barcode);

--- a/src/Schema/Schema.csproj
+++ b/src/Schema/Schema.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Packages\PackageFormat.cs" />
     <Compile Include="Packages\Download.cs" />
     <Compile Include="Packages\PackagePrice.cs" />
+    <Compile Include="Packages\Streaming.cs" />
     <Compile Include="ParameterDefinitions\Get\HasAffiliatePartnerParameter.cs" />
     <Compile Include="ParameterDefinitions\Get\HasArtistIdParameter.cs" />
     <Compile Include="ParameterDefinitions\Get\HasBasketItemParameter.cs" />

--- a/src/Schema/Tracks/Track.cs
+++ b/src/Schema/Tracks/Track.cs
@@ -78,6 +78,9 @@ namespace SevenDigital.Api.Schema.Tracks
 		[XmlElement("download")]
 		public Download Download { get; set; }
 
+		[XmlElement("subscriptionStreaming")]
+		public Streaming SubscriptionStreaming { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("{0}: {1} {2} {3}, ISRC: {4}", Id, Title, Version, Type, Isrc);


### PR DESCRIPTION
Adding new fields
- Subscription streaming node under releases and tracks for improved streaming content support.
- Optional preview date under download nodes.
- Slug element under artists and releases for easier consumption by 7digital.com

These fields are not returned by default; the usageTypes parameter must be specified.