### PR TITLE
preview date should not be serialized if empty

### DIFF
--- a/src/Schema/Packages/Download.cs
+++ b/src/Schema/Packages/Download.cs
@@ -14,6 +14,11 @@ namespace SevenDigital.Api.Schema.Packages
 		[XmlElement("previewDate")]
 		public DateTime? PreviewDate { get; set; }
 
+		public bool ShouldSerializePreviewDate()
+		{
+			return PreviewDate.HasValue;
+		}
+
 		[XmlArray("packages")]
 		[XmlArrayItem("package")]
 		public List<Package> Packages { get; set; }


### PR DESCRIPTION
Currently no previewDate gets serialized as xsi:nil. We favour omitting it altogether.