### PR TITLE
Add seperate ReleaseInLocker DTO to LockerRelease

### DIFF
--- a/src/Schema/Lockers/LockerRelease.cs
+++ b/src/Schema/Lockers/LockerRelease.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
-using SevenDigital.Api.Schema.Releases;
 
 namespace SevenDigital.Api.Schema.Lockers
 {
@@ -9,7 +8,7 @@ namespace SevenDigital.Api.Schema.Lockers
 	public class LockerRelease
 	{
 		[XmlElement("release")]
-		public Release Release { get; set; }
+		public ReleaseInLocker Release { get; set; }
 
 		[XmlArray("lockerTracks")]
 		[XmlArrayItem("lockerTrack")]

--- a/src/Schema/Lockers/ReleaseInLocker.cs
+++ b/src/Schema/Lockers/ReleaseInLocker.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Xml.Serialization;
+using SevenDigital.Api.Schema.Artists;
+using SevenDigital.Api.Schema.Releases;
+
+namespace SevenDigital.Api.Schema.Lockers
+{
+	[Serializable]
+	public class ReleaseInLocker
+	{
+		[XmlAttribute("id")]
+		public int Id { get; set; }
+
+		[XmlElement("title")]
+		public string Title { get; set; }
+
+		[XmlElement("version")]
+		public string Version { get; set; }
+
+		[XmlElement("type")]
+		public ReleaseType Type { get; set; }
+
+		[XmlElement("barcode")]
+		public string Barcode { get; set; }
+
+		[XmlElement("artist")]
+		public Artist Artist { get; set; }
+
+		[XmlElement("url")]
+		public string Url { get; set; }
+
+		[XmlElement("image")]
+		public string Image { get; set; }
+
+		[XmlElement("releaseDate")]
+		public DateTime ReleaseDate { get; set; }
+
+		[XmlElement("licensor")]
+		public Licensor Licensor { get; set; }
+
+		public override string ToString()
+		{
+			return string.Format("{0}: {1} {2} {3}, Barcode {4}", Id, Title, Version, Type, Barcode);
+		}
+	}
+}

--- a/src/Schema/Schema.csproj
+++ b/src/Schema/Schema.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Lockers\Locker.cs" />
     <Compile Include="Lockers\LockerRelease.cs" />
     <Compile Include="Lockers\LockerTrack.cs" />
+    <Compile Include="Lockers\ReleaseInLocker.cs" />
     <Compile Include="Matching\ArtistMatchResponse.cs" />
     <Compile Include="Matching\MatchError.cs" />
     <Compile Include="Matching\ReleaseMatchResponse.cs" />


### PR DESCRIPTION
The Release entity in locker/lockerReleases/lockerRelease/release has diverged sufficiently from the original Release DTO to warrant a separate DTO, this PR adds that DTO. 

Named `ReleaseInLocker` so as not to clash with `LockerRelease`, its parent element, but could do with a better name?

Biggest problem at the moment, is that `ReleaseDate` in `Release` is marked as Obselete, but Locker still uses it, and there's no other way without an extra call per release to release/details to get the release date.
