### PR TITLE
Remove PlaylistStatusType enum, now Status is to be a string so custo…

### DIFF
--- a/src/Schema.Unit.Tests/EntitySerialization/Playlists/SerializationTests.cs
+++ b/src/Schema.Unit.Tests/EntitySerialization/Playlists/SerializationTests.cs
@@ -37,7 +37,7 @@ namespace SevenDigital.Api.Schema.Unit.Tests.EntitySerialization.Playlists
 			Assert.That(playlist.Id, Is.EqualTo("51ed5cfec9021614f462bb7b"));
 			Assert.That(playlist.Name, Is.EqualTo("party time"));
 			Assert.That(playlist.Description, Is.EqualTo("Hits to get the party started"));
-			Assert.That(playlist.Status, Is.EqualTo(PlaylistStatusType.Published));
+			Assert.That(playlist.Status, Is.EqualTo("Published"));
 			Assert.That(playlist.Visibility, Is.EqualTo(PlaylistVisibilityType.Public));
 			Assert.That(playlist.ImageUrl, Is.EqualTo("http://artwork-cdn.7static.com/static/img/sleeveart/00/004/963/0000496338_$size$.jpg"));
 
@@ -82,7 +82,7 @@ namespace SevenDigital.Api.Schema.Unit.Tests.EntitySerialization.Playlists
 			Assert.That(playlist.Id, Is.EqualTo("51ed5cfec9021614f462bb7b"));
 			Assert.That(playlist.Name, Is.EqualTo("party time"));
 			Assert.That(playlist.Description, Is.EqualTo("Hits to get the party started"));
-			Assert.That(playlist.Status, Is.EqualTo(PlaylistStatusType.Published));
+			Assert.That(playlist.Status, Is.EqualTo("published"));
 			Assert.That(playlist.Visibility, Is.EqualTo(PlaylistVisibilityType.Public));
 			Assert.That(playlist.ImageUrl, Is.EqualTo("http://artwork-cdn.7static.com/static/img/sleeveart/00/004/963/0000496338_$size$.jpg"));
 
@@ -118,7 +118,7 @@ namespace SevenDigital.Api.Schema.Unit.Tests.EntitySerialization.Playlists
 					new Product { TrackId = "12345" },
 					new Product { TrackId = "98765"}
 				},
-				Status = PlaylistStatusType.Published,
+				Status = "Published",
 				Tags = new List<Tag>
 				{
 					new Tag { Name = "tag1", PlaylistPosition = 1 },
@@ -163,7 +163,7 @@ namespace SevenDigital.Api.Schema.Unit.Tests.EntitySerialization.Playlists
 					new Product { TrackId = "12345" },
 					new Product { TrackId = "98765"}
 				},
-				Status = PlaylistStatusType.Published,
+				Status = "Published",
 				Tags = new List<Tag>
 				{
 					new Tag { Name="tag1", PlaylistPosition=1 },

--- a/src/Schema/Playlists/PlaylistStatusType.cs
+++ b/src/Schema/Playlists/PlaylistStatusType.cs
@@ -1,9 +1,0 @@
-﻿namespace SevenDigital.Api.Schema.Playlists
-{
-	public enum PlaylistStatusType
-	{
-		NotSpecified,
-		Draft,
-		Published
-	}
-}

--- a/src/Schema/Playlists/Requests/PlaylistDetailsRequest.cs
+++ b/src/Schema/Playlists/Requests/PlaylistDetailsRequest.cs
@@ -23,7 +23,7 @@ namespace SevenDigital.Api.Schema.Playlists.Requests
 		public PlaylistVisibilityType Visibility { get; set; }
 
 		[XmlElement("status")]
-		public PlaylistStatusType Status { get; set; }
+		public string Status { get; set; }
 
 		[XmlElement("description")]
 		public string Description { get; set; }

--- a/src/Schema/Playlists/Response/Endpoints/PlaylistDetails.cs
+++ b/src/Schema/Playlists/Response/Endpoints/PlaylistDetails.cs
@@ -29,7 +29,7 @@ namespace SevenDigital.Api.Schema.Playlists.Response.Endpoints
 		public PlaylistVisibilityType Visibility { get; set; }
 
 		[XmlElement("status")]
-		public PlaylistStatusType Status { get; set; }
+		public string Status { get; set; }
 
 		[XmlElement("description")]
 		public string Description { get; set; }

--- a/src/Schema/Playlists/Response/PlaylistLocation.cs
+++ b/src/Schema/Playlists/Response/PlaylistLocation.cs
@@ -32,7 +32,7 @@ namespace SevenDigital.Api.Schema.Playlists.Response
 		public string Image { get; set; }
 
 		[XmlElement("status")]
-		public PlaylistStatusType Status { get; set; }
+		public string Status { get; set; }
 
 		[XmlArray("tags")]
 		[XmlArrayItem("tag")]

--- a/src/Schema/Schema.csproj
+++ b/src/Schema/Schema.csproj
@@ -111,7 +111,6 @@
     <Compile Include="Playlists\AnnotationsJsonConverter.cs" />
     <Compile Include="Playlists\HasPlaylistIdParameter.cs" />
     <Compile Include="Playlists\HasPlaylistTrackIdParameter.cs" />
-    <Compile Include="Playlists\PlaylistStatusType.cs" />
     <Compile Include="Playlists\PlaylistVisibilityType.cs" />
     <Compile Include="Playlists\Product.cs" />
     <Compile Include="Playlists\Requests\PlaylistDetailsRequest.cs" />


### PR DESCRIPTION
…m statuses can be used

I've done this as a PR so as Platform Tools can double check

Basically the idea is this:

1. Remove enum parsing of status response
2. Release with a new major version (as breaking changes)
3. Can then be imported into PT (or any other consuming apps) and usage can be changed to string.

Not updating would only cause an issue in the following case:

1. Playlist has status set to string not that's not one of the 3 statuses defined in the existing enum.
2. PT (or other app with older version) consumes this playlist.

